### PR TITLE
Add document model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 *.exe
 .DS_Store
 
+document/*.pdf
 rsa/private-key.pem
 rsa/public-key.pem

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -54,4 +54,3 @@ models:
       - github.com/99designs/gqlgen/graphql.Int
       - github.com/99designs/gqlgen/graphql.Int64
       - github.com/99designs/gqlgen/graphql.Int32
-  

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -239,15 +239,14 @@ var sources = []*ast.Source{
      file: String!
 }
 
-input documentInput {
-      id: ID!
+input DocumentInput {
       title: String!
       description: String!
       file: String!
 }
 
 type Mutation {
-     createDocument(input: documentInput!): GraphDocument!
+     createDocument(input: DocumentInput!): GraphDocument!
 }`, BuiltIn: false},
 	&ast.Source{Name: "schema/users.graphql", Input: `type GraphUser {
      id: ID!
@@ -272,7 +271,7 @@ func (ec *executionContext) field_Mutation_createDocument_args(ctx context.Conte
 	args := map[string]interface{}{}
 	var arg0 model.DocumentInput
 	if tmp, ok := rawArgs["input"]; ok {
-		arg0, err = ec.unmarshalNdocumentInput2githubᚗcomᚋyamakenji24ᚋbinderᚑapiᚋgraphᚋmodelᚐDocumentInput(ctx, tmp)
+		arg0, err = ec.unmarshalNDocumentInput2githubᚗcomᚋyamakenji24ᚋbinderᚑapiᚋgraphᚋmodelᚐDocumentInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -1823,18 +1822,12 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 
 // region    **************************** input.gotpl *****************************
 
-func (ec *executionContext) unmarshalInputdocumentInput(ctx context.Context, obj interface{}) (model.DocumentInput, error) {
+func (ec *executionContext) unmarshalInputDocumentInput(ctx context.Context, obj interface{}) (model.DocumentInput, error) {
 	var it model.DocumentInput
 	var asMap = obj.(map[string]interface{})
 
 	for k, v := range asMap {
 		switch k {
-		case "id":
-			var err error
-			it.ID, err = ec.unmarshalNID2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
 		case "title":
 			var err error
 			it.Title, err = ec.unmarshalNString2string(ctx, v)
@@ -2285,6 +2278,10 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
+func (ec *executionContext) unmarshalNDocumentInput2githubᚗcomᚋyamakenji24ᚋbinderᚑapiᚋgraphᚋmodelᚐDocumentInput(ctx context.Context, v interface{}) (model.DocumentInput, error) {
+	return ec.unmarshalInputDocumentInput(ctx, v)
+}
+
 func (ec *executionContext) marshalNGraphDocument2githubᚗcomᚋyamakenji24ᚋbinderᚑapiᚋgraphᚋmodelᚐGraphDocument(ctx context.Context, sel ast.SelectionSet, v model.GraphDocument) graphql.Marshaler {
 	return ec._GraphDocument(ctx, sel, &v)
 }
@@ -2565,10 +2562,6 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 		}
 	}
 	return res
-}
-
-func (ec *executionContext) unmarshalNdocumentInput2githubᚗcomᚋyamakenji24ᚋbinderᚑapiᚋgraphᚋmodelᚐDocumentInput(ctx context.Context, v interface{}) (model.DocumentInput, error) {
-	return ec.unmarshalInputdocumentInput(ctx, v)
 }
 
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interface{}) (bool, error) {

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -42,6 +42,13 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+	GraphDocument struct {
+		Description func(childComplexity int) int
+		File        func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Title       func(childComplexity int) int
+	}
+
 	GraphUser struct {
 		Email    func(childComplexity int) int
 		ID       func(childComplexity int) int
@@ -51,6 +58,10 @@ type ComplexityRoot struct {
 
 	Query struct {
 		User func(childComplexity int, username string) int
+	}
+
+	Mutation struct {
+		CreateDocument func(childComplexity int, input model.DocumentInput) int
 	}
 }
 
@@ -72,6 +83,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	ec := executionContext{nil, e}
 	_ = ec
 	switch typeName + "." + field {
+
+	case "GraphDocument.description":
+		if e.complexity.GraphDocument.Description == nil {
+			break
+		}
+
+		return e.complexity.GraphDocument.Description(childComplexity), true
+
+	case "GraphDocument.file":
+		if e.complexity.GraphDocument.File == nil {
+			break
+		}
+
+		return e.complexity.GraphDocument.File(childComplexity), true
+
+	case "GraphDocument.ID":
+		if e.complexity.GraphDocument.ID == nil {
+			break
+		}
+
+		return e.complexity.GraphDocument.ID(childComplexity), true
+
+	case "GraphDocument.title":
+		if e.complexity.GraphDocument.Title == nil {
+			break
+		}
+
+		return e.complexity.GraphDocument.Title(childComplexity), true
 
 	case "GraphUser.email":
 		if e.complexity.GraphUser.Email == nil {
@@ -112,6 +151,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.User(childComplexity, args["username"].(string)), true
+
+	case "mutation.createDocument":
+		if e.complexity.Mutation.CreateDocument == nil {
+			break
+		}
+
+		args, err := ec.field_mutation_createDocument_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateDocument(childComplexity, args["input"].(model.DocumentInput)), true
 
 	}
 	return 0, false
@@ -163,6 +214,23 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
+	&ast.Source{Name: "schema/documents.graphql", Input: `type GraphDocument {
+     ID: ID!
+     title: String!
+     description: String!
+     file: String!
+}
+
+input documentInput {
+      ID: ID!
+      title: String!
+      description: String!
+      file: String!
+}
+
+type mutation {
+     createDocument(input: documentInput!): GraphDocument!
+}`, BuiltIn: false},
 	&ast.Source{Name: "schema/users.graphql", Input: `type GraphUser {
      id: ID!
      username: String!
@@ -170,15 +238,9 @@ var sources = []*ast.Source{
      email: String!
 }
 
-input LoginInput {
-      username: String!
-      password: String!
-}
-
 type Query {
      user(username: String!): GraphUser!
 }
-
 `, BuiltIn: false},
 }
 var parsedSchema = gqlparser.MustLoadSchema(sources...)
@@ -243,6 +305,20 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 	return args, nil
 }
 
+func (ec *executionContext) field_mutation_createDocument_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.DocumentInput
+	if tmp, ok := rawArgs["input"]; ok {
+		arg0, err = ec.unmarshalNdocumentInput2githubᚗcomᚋyamakenji24ᚋbinderᚑapiᚋgraphᚋmodelᚐDocumentInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
 // endregion ***************************** args.gotpl *****************************
 
 // region    ************************** directives.gotpl **************************
@@ -250,6 +326,142 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 // endregion ************************** directives.gotpl **************************
 
 // region    **************************** field.gotpl *****************************
+
+func (ec *executionContext) _GraphDocument_ID(ctx context.Context, field graphql.CollectedField, obj *model.GraphDocument) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "GraphDocument",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _GraphDocument_title(ctx context.Context, field graphql.CollectedField, obj *model.GraphDocument) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "GraphDocument",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Title, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _GraphDocument_description(ctx context.Context, field graphql.CollectedField, obj *model.GraphDocument) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "GraphDocument",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _GraphDocument_file(ctx context.Context, field graphql.CollectedField, obj *model.GraphDocument) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "GraphDocument",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.File, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
 
 func (ec *executionContext) _GraphUser_id(ctx context.Context, field graphql.CollectedField, obj *model.GraphUser) (ret graphql.Marshaler) {
 	defer func() {
@@ -1548,25 +1760,78 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 	return ec.marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _mutation_createDocument(ctx context.Context, field graphql.CollectedField, obj *model.Mutation) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_mutation_createDocument_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreateDocument, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.GraphDocument)
+	fc.Result = res
+	return ec.marshalNGraphDocument2ᚖgithubᚗcomᚋyamakenji24ᚋbinderᚑapiᚋgraphᚋmodelᚐGraphDocument(ctx, field.Selections, res)
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
 
-func (ec *executionContext) unmarshalInputLoginInput(ctx context.Context, obj interface{}) (model.LoginInput, error) {
-	var it model.LoginInput
+func (ec *executionContext) unmarshalInputdocumentInput(ctx context.Context, obj interface{}) (model.DocumentInput, error) {
+	var it model.DocumentInput
 	var asMap = obj.(map[string]interface{})
 
 	for k, v := range asMap {
 		switch k {
-		case "username":
+		case "ID":
 			var err error
-			it.Username, err = ec.unmarshalNString2string(ctx, v)
+			it.ID, err = ec.unmarshalNID2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
-		case "password":
+		case "title":
 			var err error
-			it.Password, err = ec.unmarshalNString2string(ctx, v)
+			it.Title, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "description":
+			var err error
+			it.Description, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "file":
+			var err error
+			it.File, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -1583,6 +1848,48 @@ func (ec *executionContext) unmarshalInputLoginInput(ctx context.Context, obj in
 // endregion ************************** interface.gotpl ***************************
 
 // region    **************************** object.gotpl ****************************
+
+var graphDocumentImplementors = []string{"GraphDocument"}
+
+func (ec *executionContext) _GraphDocument(ctx context.Context, sel ast.SelectionSet, obj *model.GraphDocument) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, graphDocumentImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("GraphDocument")
+		case "ID":
+			out.Values[i] = ec._GraphDocument_ID(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "title":
+			out.Values[i] = ec._GraphDocument_title(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "description":
+			out.Values[i] = ec._GraphDocument_description(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "file":
+			out.Values[i] = ec._GraphDocument_file(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
 
 var graphUserImplementors = []string{"GraphUser"}
 
@@ -1911,6 +2218,33 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 	return out
 }
 
+var mutationImplementors = []string{"mutation"}
+
+func (ec *executionContext) _mutation(ctx context.Context, sel ast.SelectionSet, obj *model.Mutation) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, mutationImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("mutation")
+		case "createDocument":
+			out.Values[i] = ec._mutation_createDocument(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 // endregion **************************** object.gotpl ****************************
 
 // region    ***************************** type.gotpl *****************************
@@ -1927,6 +2261,20 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNGraphDocument2githubᚗcomᚋyamakenji24ᚋbinderᚑapiᚋgraphᚋmodelᚐGraphDocument(ctx context.Context, sel ast.SelectionSet, v model.GraphDocument) graphql.Marshaler {
+	return ec._GraphDocument(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNGraphDocument2ᚖgithubᚗcomᚋyamakenji24ᚋbinderᚑapiᚋgraphᚋmodelᚐGraphDocument(ctx context.Context, sel ast.SelectionSet, v *model.GraphDocument) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._GraphDocument(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNGraphUser2githubᚗcomᚋyamakenji24ᚋbinderᚑapiᚋgraphᚋmodelᚐGraphUser(ctx context.Context, sel ast.SelectionSet, v model.GraphUser) graphql.Marshaler {
@@ -2195,6 +2543,10 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNdocumentInput2githubᚗcomᚋyamakenji24ᚋbinderᚑapiᚋgraphᚋmodelᚐDocumentInput(ctx context.Context, v interface{}) (model.DocumentInput, error) {
+	return ec.unmarshalInputdocumentInput(ctx, v)
 }
 
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interface{}) (bool, error) {

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -98,7 +98,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.GraphDocument.File(childComplexity), true
 
-	case "GraphDocument.ID":
+	case "GraphDocument.id":
 		if e.complexity.GraphDocument.ID == nil {
 			break
 		}
@@ -215,14 +215,14 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 
 var sources = []*ast.Source{
 	&ast.Source{Name: "schema/documents.graphql", Input: `type GraphDocument {
-     ID: ID!
+     id: ID!
      title: String!
      description: String!
      file: String!
 }
 
 input documentInput {
-      ID: ID!
+      id: ID!
       title: String!
       description: String!
       file: String!
@@ -327,7 +327,7 @@ func (ec *executionContext) field_mutation_createDocument_args(ctx context.Conte
 
 // region    **************************** field.gotpl *****************************
 
-func (ec *executionContext) _GraphDocument_ID(ctx context.Context, field graphql.CollectedField, obj *model.GraphDocument) (ret graphql.Marshaler) {
+func (ec *executionContext) _GraphDocument_id(ctx context.Context, field graphql.CollectedField, obj *model.GraphDocument) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -1811,7 +1811,7 @@ func (ec *executionContext) unmarshalInputdocumentInput(ctx context.Context, obj
 
 	for k, v := range asMap {
 		switch k {
-		case "ID":
+		case "id":
 			var err error
 			it.ID, err = ec.unmarshalNID2string(ctx, v)
 			if err != nil {
@@ -1860,8 +1860,8 @@ func (ec *executionContext) _GraphDocument(ctx context.Context, sel ast.Selectio
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("GraphDocument")
-		case "ID":
-			out.Values[i] = ec._GraphDocument_ID(ctx, field, obj)
+		case "id":
+			out.Values[i] = ec._GraphDocument_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -22,7 +22,3 @@ type DocumentInput struct {
 	Description string `json:"description"`
 	File        string `json:"file"`
 }
-
-type Mutation struct {
-	CreateDocument *GraphDocument `json:"createDocument"`
-}

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -2,6 +2,13 @@
 
 package model
 
+type GraphDocument struct {
+	ID          string `json:"ID"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	File        string `json:"file"`
+}
+
 type GraphUser struct {
 	ID       string `json:"id"`
 	Username string `json:"username"`
@@ -9,7 +16,13 @@ type GraphUser struct {
 	Email    string `json:"email"`
 }
 
-type LoginInput struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+type DocumentInput struct {
+	ID          string `json:"ID"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	File        string `json:"file"`
+}
+
+type Mutation struct {
+	CreateDocument *GraphDocument `json:"createDocument"`
 }

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -2,6 +2,12 @@
 
 package model
 
+type DocumentInput struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	File        string `json:"file"`
+}
+
 type GraphDocument struct {
 	ID          string `json:"id"`
 	Title       string `json:"title"`
@@ -14,11 +20,4 @@ type GraphUser struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
 	Email    string `json:"email"`
-}
-
-type DocumentInput struct {
-	ID          string `json:"id"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	File        string `json:"file"`
 }

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -3,7 +3,7 @@
 package model
 
 type GraphDocument struct {
-	ID          string `json:"ID"`
+	ID          string `json:"id"`
 	Title       string `json:"title"`
 	Description string `json:"description"`
 	File        string `json:"file"`
@@ -17,7 +17,7 @@ type GraphUser struct {
 }
 
 type DocumentInput struct {
-	ID          string `json:"ID"`
+	ID          string `json:"id"`
 	Title       string `json:"title"`
 	Description string `json:"description"`
 	File        string `json:"file"`

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -36,6 +36,7 @@ func main() {
 	}
 
 	db.AutoMigrate(&model.User{})
+	db.AutoMigrate(&model.Document{})
 
 	sampleUser := model.User{
 		Username: "yamakenji24",

--- a/model/document.go
+++ b/model/document.go
@@ -1,0 +1,11 @@
+package model
+
+import "github.com/jinzhu/gorm"
+
+type Document struct {
+	gorm.Model
+	UserID      int    `gorm:"not null"`
+	Title       string `gorm:"size:255;nut null"`
+	Description string `gorm:"not null"`
+	FilePath    string `gorm:"size:255;not null"`
+}

--- a/repository/document_repository.go
+++ b/repository/document_repository.go
@@ -1,0 +1,17 @@
+package repository
+
+import "github.com/yamakenji24/binder-api/model"
+
+func CreateNewDocument(userID int, title string, description string, filepath string) (*model.Document, error) {
+	db := NewSQLHandler()
+	doc := model.Document{
+		UserID:      userID,
+		Title:       title,
+		Description: description,
+		FilePath:    filepath,
+	}
+	if err := db.Create(&doc).Error; err != nil {
+		return nil, err
+	}
+	return &doc, nil
+}

--- a/resolver/documents.resolvers.go
+++ b/resolver/documents.resolvers.go
@@ -6,21 +6,29 @@ package resolver
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
+	"os"
+	"strconv"
+	"time"
 
 	"github.com/yamakenji24/binder-api/graph/generated"
 	"github.com/yamakenji24/binder-api/graph/model"
+	"github.com/yamakenji24/binder-api/repository"
 )
 
 func (r *mutationResolver) CreateDocument(ctx context.Context, input model.DocumentInput) (*model.GraphDocument, error) {
+	userID, _ := ctx.Value("userId").(int)
+	filepath, err := decodeFile(userID, input.Title, input.File)
+	if err != nil {
+		return &model.GraphDocument{}, err
+	}
 
-	decData := decodeFile(1, input.Title, input.File)
-	fmt.Println(decData)
+	// DB 登録とか？
+	doc, err := repository.CreateNewDocument(userID, input.Title, input.Description, filepath)
 
 	return &model.GraphDocument{
-		ID:          "1",
-		Title:       input.Title,
-		Description: input.Description,
+		ID:          strconv.FormatUint(uint64(doc.ID), 10),
+		Title:       doc.Title,
+		Description: doc.Description,
 		File:        input.File,
 	}, nil
 }
@@ -30,9 +38,20 @@ func (r *Resolver) Mutation() generated.MutationResolver { return &mutationResol
 
 type mutationResolver struct{ *Resolver }
 
-func decodeFile(id int, title string, file string) []byte {
+func decodeFile(id int, title string, inputfile string) (string, error) {
+	data, err := base64.StdEncoding.DecodeString(inputfile)
+	if err != nil {
+		return "", err
+	}
+	dir, err := os.Getwd()
+	fp := dir + "/document/" + strconv.Itoa(id) + "_" + strconv.FormatInt(time.Now().Unix(), 10) + ".pdf"
 
-	data, _ := base64.StdEncoding.DecodeString(file)
+	file, err := os.Create(fp)
+	defer file.Close()
+	file.Write(data)
+	if err != nil {
+		return "", err
+	}
 
-	return data
+	return fp, nil
 }

--- a/resolver/documents.resolvers.go
+++ b/resolver/documents.resolvers.go
@@ -12,7 +12,15 @@ import (
 )
 
 func (r *mutationResolver) CreateDocument(ctx context.Context, input model.DocumentInput) (*model.GraphDocument, error) {
-	panic(fmt.Errorf("not implemented"))
+	fmt.Println("calling createdocument")
+	fmt.Println(input)
+
+	return &model.GraphDocument{
+		ID:          "1",
+		Title:       input.Title,
+		Description: input.Description,
+		File:        input.File,
+	}, nil
 }
 
 // Mutation returns generated.MutationResolver implementation.

--- a/resolver/documents.resolvers.go
+++ b/resolver/documents.resolvers.go
@@ -1,0 +1,21 @@
+package resolver
+
+// This file will be automatically regenerated based on the schema, any resolver implementations
+// will be copied through when generating and any unknown code will be moved to the end.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/yamakenji24/binder-api/graph/generated"
+	"github.com/yamakenji24/binder-api/graph/model"
+)
+
+func (r *mutationResolver) CreateDocument(ctx context.Context, input model.DocumentInput) (*model.GraphDocument, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
+// Mutation returns generated.MutationResolver implementation.
+func (r *Resolver) Mutation() generated.MutationResolver { return &mutationResolver{r} }
+
+type mutationResolver struct{ *Resolver }

--- a/resolver/documents.resolvers.go
+++ b/resolver/documents.resolvers.go
@@ -5,6 +5,7 @@ package resolver
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	"github.com/yamakenji24/binder-api/graph/generated"
@@ -12,8 +13,9 @@ import (
 )
 
 func (r *mutationResolver) CreateDocument(ctx context.Context, input model.DocumentInput) (*model.GraphDocument, error) {
-	fmt.Println("calling createdocument")
-	fmt.Println(input)
+
+	decData := decodeFile(1, input.Title, input.File)
+	fmt.Println(decData)
 
 	return &model.GraphDocument{
 		ID:          "1",
@@ -27,3 +29,10 @@ func (r *mutationResolver) CreateDocument(ctx context.Context, input model.Docum
 func (r *Resolver) Mutation() generated.MutationResolver { return &mutationResolver{r} }
 
 type mutationResolver struct{ *Resolver }
+
+func decodeFile(id int, title string, file string) []byte {
+
+	data, _ := base64.StdEncoding.DecodeString(file)
+
+	return data
+}

--- a/resolver/users.resolvers.go
+++ b/resolver/users.resolvers.go
@@ -5,7 +5,6 @@ package resolver
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/yamakenji24/binder-api/graph/generated"
@@ -14,8 +13,6 @@ import (
 )
 
 func (r *queryResolver) User(ctx context.Context, username string) (*model.GraphUser, error) {
-	userid := ctx.Value("userId")
-	fmt.Println(userid)
 	user, err := repository.GetUserByName(username)
 	if err != nil {
 		return &model.GraphUser{}, err

--- a/resolver/users.resolvers.go
+++ b/resolver/users.resolvers.go
@@ -13,6 +13,8 @@ import (
 )
 
 func (r *queryResolver) User(ctx context.Context, username string) (*model.GraphUser, error) {
+	userid := ctx.Value("userId")
+
 	user, err := repository.GetUserByName(username)
 	if err != nil {
 		return &model.GraphUser{}, err

--- a/resolver/users.resolvers.go
+++ b/resolver/users.resolvers.go
@@ -5,6 +5,7 @@ package resolver
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/yamakenji24/binder-api/graph/generated"
@@ -14,7 +15,7 @@ import (
 
 func (r *queryResolver) User(ctx context.Context, username string) (*model.GraphUser, error) {
 	userid := ctx.Value("userId")
-
+	fmt.Println(userid)
 	user, err := repository.GetUserByName(username)
 	if err != nil {
 		return &model.GraphUser{}, err

--- a/schema/documents.graphql
+++ b/schema/documents.graphql
@@ -5,13 +5,12 @@ type GraphDocument {
      file: String!
 }
 
-input documentInput {
-      id: ID!
+input DocumentInput {
       title: String!
       description: String!
       file: String!
 }
 
 type Mutation {
-     createDocument(input: documentInput!): GraphDocument!
+     createDocument(input: DocumentInput!): GraphDocument!
 }

--- a/schema/documents.graphql
+++ b/schema/documents.graphql
@@ -1,0 +1,17 @@
+type GraphDocument {
+     ID: ID!
+     title: String!
+     description: String!
+     file: String!
+}
+
+input documentInput {
+      ID: ID!
+      title: String!
+      description: String!
+      file: String!
+}
+
+type mutation {
+     createDocument(input: documentInput!): GraphDocument!
+}

--- a/schema/documents.graphql
+++ b/schema/documents.graphql
@@ -1,12 +1,12 @@
 type GraphDocument {
-     ID: ID!
+     id: ID!
      title: String!
      description: String!
      file: String!
 }
 
 input documentInput {
-      ID: ID!
+      id: ID!
       title: String!
       description: String!
       file: String!

--- a/schema/documents.graphql
+++ b/schema/documents.graphql
@@ -12,6 +12,6 @@ input documentInput {
       file: String!
 }
 
-type mutation {
+type Mutation {
      createDocument(input: documentInput!): GraphDocument!
 }

--- a/schema/users.graphql
+++ b/schema/users.graphql
@@ -5,12 +5,6 @@ type GraphUser {
      email: String!
 }
 
-input LoginInput {
-      username: String!
-      password: String!
-}
-
 type Query {
      user(username: String!): GraphUser!
 }
-

--- a/server.go
+++ b/server.go
@@ -22,7 +22,7 @@ func graphqlHandler() gin.HandlerFunc {
 		r := c.Request
 		userId, exist := c.Get("userId")
 		if !exist {
-			h.ServeHTTP(c.Writer, c.Request)
+			h.ServeHTTP(c.Writer, r)
 		} else {
 			ctx := context.WithValue(r.Context(), "userId", userId.(int))
 			h.ServeHTTP(c.Writer, r.WithContext(ctx))


### PR DESCRIPTION
DocumentのDB処理を行った。
現状として、userID、タイトル、概要、pdfファイルを保存することを想定している。
pdfファイルは、base64にエンコードしたものをデコードし、filepathでdbに登録する。
ファイル名は、userID_Unix timeを採用した。

今後としては、ファイルのタグ分類も想定しているため、その辺りも対応して行く。